### PR TITLE
Allow only either `minimum` or `maximum` to be specified

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ mathClamp(1, {minimum: 2, maximum: 4});
 
 ## API
 
-### mathClamp(number, {minimum, maximum})
+### mathClamp(number, {minimum?, maximum?})
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,12 @@ import mathClamp from 'math-clamp';
 
 mathClamp(1, {minimum: 2, maximum: 4});
 //=> 2
+
+mathClamp(1, {minimum: 2});
+//=> 2
+
+mathClamp(5, {maximum: 4});
+//=> 4
 ```
 
 ## API

--- a/test.js
+++ b/test.js
@@ -6,4 +6,10 @@ test('main', t => {
 	t.is(mathClamp(2, {minimum: 1, maximum: 3}), 2);
 	t.is(mathClamp(1, {minimum: 2, maximum: 4}), 2);
 	t.is(mathClamp(5, {minimum: 1, maximum: 4}), 4);
+	t.is(mathClamp(5, {minimum: 1}), 5);
+	t.is(mathClamp(1, {minimum: 1}), 1);
+	t.is(mathClamp(0, {minimum: 1}), 1);
+	t.is(mathClamp(5, {maximum: 1}), 1);
+	t.is(mathClamp(1, {maximum: 1}), 1);
+	t.is(mathClamp(0, {maximum: 1}), 0);
 });


### PR DESCRIPTION
The use case is to decrease cognitive load.

Before:

```js
// Clamp score to a lower bound of 0
Math.max(score, 0);
```

After:

```js
mathClamp(score, {minimum: 0});
```