### PR TITLE
Avoid compare with `undefined`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
-export default function mathClamp(number, {min, minimum, max, maximum}) {
-	// TODO: Remove `minimum` and `maximum` options in the next breaking release
-	min ??= minimum;
-	max ??= maximum;
-
+// TODO: Remove `minimum` and `maximum` options in the next breaking release
+export default function mathClamp(number, {
+	minimum = number,
+	min = minimum,
+	maximum = number,
+	max = maximum,
+}) {
 	if (min > max) {
 		throw new RangeError('`min` should be lower than `max`');
 	}

--- a/index.js
+++ b/index.js
@@ -1,18 +1,20 @@
 // TODO: Remove `minimum` and `maximum` options in the next breaking release
 export default function mathClamp(number, {
-	minimum = number,
+	minimum,
 	min = minimum,
-	maximum = number,
+	minimum,
 	max = maximum,
 }) {
 	if (min > max) {
 		throw new RangeError('`min` should be lower than `max`');
 	}
 
+	min ??= number;
 	if (number < min) {
 		return min;
 	}
 
+	max ??= number;
 	if (number > max) {
 		return max;
 	}


### PR DESCRIPTION
Since `min` can be omitted, we are actually comparing number with `undefined`, which is confusing...

I just read the spec to understand how it works..