### PR TITLE
Move default condition last

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
 	},
 	"type": "module",
 	"exports": {
-		"default": "./index.js",
-		"types": "./index.d.ts"
+		"types": "./index.d.ts",
+		"default": "./index.js"
 	},
 	"sideEffects": false,
 	"engines": {


### PR DESCRIPTION
Hi,

There's a compilation error happening with Next.js when using `math-clamp` v2.2.0:

>Module not found: Default condition should be last one

However, it doesn't happen with v2.1.0. It was most likely caused by #14 because it's the only commit contained in v2.2.0.

More specifically caused by the changes in `package.json` where a `default` exports entry was added and was not the last one, as the error indicates.

As reference, a similar issue was reported in [firebase-js-sdk](https://github.com/firebase/firebase-js-sdk/issues/7005). The root cause was the same, [a PR](https://github.com/firebase/firebase-js-sdk/pull/6981) where `package.json` changed in a similar matter. The solution was to move the entry to be last as shown [in this PR](https://github.com/firebase/firebase-js-sdk/pull/7007).

This PR attempts to fix the issue in the same way.

Feel free to let me know if I should make further changes.

Thanks!